### PR TITLE
Support "." in parameter names

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Rust2Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Rust2Codegen.java
@@ -309,7 +309,8 @@ public class Rust2Codegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String toParamName(String name) {
-        return underscore(super.toParamName(name));
+        // should be the same as variable name (stolen from RubyClientCodegen)
+        return toVarName(name);
     }
 
     @Override


### PR DESCRIPTION
The `underscore` method converts `.` to `/`, which is not legal in a Rust variable name. This commit uses the `.` to `_` mechanism that is used for variables.