### PR TITLE
Support "." in parameter names

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Rust2Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Rust2Codegen.java
@@ -312,7 +312,8 @@ public class Rust2Codegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String toParamName(String name) {
-        return underscore(super.toParamName(name));
+        // should be the same as variable name (stolen from RubyClientCodegen)
+        return toVarName(name);
     }
 
     @Override


### PR DESCRIPTION
I do not know where my previous pull request with this change went.

Without this change, invalid code is generated for any parameter that contains a `.` in the name.
This https://watson-api-explorer.mybluemix.net/listings/discovery-v1.json real world swagger demonstrates the problem. Unfortunately, that swagger has other issues, which confuses things a bit.
